### PR TITLE
feat: add ApiGatewayClient, refactor in packages, add tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Description
+
+Describe your changes, and WHY you made them
+
+
+## Testing
+
+Describe how you tested your changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Package build and Unit tests
+
+on:
+  pull_request:
+    branches: [ mainline ]
+  push:
+    branches: [ mainline ]
+
+permissions:
+  packages: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Create Maven settings.xml
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: '[{"id": "github", "username": "trjohnny", "password": "${{env.GITHUB_TOKEN}}"}]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy maven package
+
+on:
+  push:
+    branches: [ mainline ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.MAVEN_DEPLOY_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,16 @@
       <version>4.12.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.4.1</version>
+    </dependency>
 
     <dependency>
       <groupId>com.aerotrack</groupId>
       <artifactId>aerotrack-model</artifactId>
-      <version>1.0.6</version>
+      <version>1.0.11</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/com/aerotrack/utils/clients/ApiClientWrapper.java
+++ b/src/main/java/com/aerotrack/utils/clients/ApiClientWrapper.java
@@ -1,0 +1,79 @@
+package com.aerotrack.utils.clients;
+
+import com.aerotrack.model.exceptions.ApiRequestException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+@Slf4j
+public class ApiClientWrapper {
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public ApiClientWrapper() {
+        this.httpClient = HttpClient.newHttpClient();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public <T> T sendPostRequest(String endpointUrl, Optional<String> apiKey, Object requestObject, Class<T> responseType) {
+        try {
+            String requestBody = objectMapper.writeValueAsString(requestObject);
+            HttpRequest request = buildRequest(endpointUrl, apiKey, HttpRequest.BodyPublishers.ofString(requestBody), "POST");
+            log.info("Sending HTTP POST request: {}", request);
+
+            return handleResponse(httpClient.send(request, HttpResponse.BodyHandlers.ofString()), responseType);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing/deserializing JSON: " + e.getMessage());
+            throw new ApiRequestException("JSON processing error", e);
+        } catch (IOException | InterruptedException e) {
+            log.error("Error in API request: " + e.getMessage());
+            throw new ApiRequestException("API request error", e);
+        }
+    }
+
+    public <T> T sendGetRequest(String endpointUrl, Optional<String> apiKey, Class<T> responseType) {
+        try {
+            HttpRequest request = buildRequest(endpointUrl, apiKey, HttpRequest.BodyPublishers.noBody(), "GET");
+            log.info("Sending HTTP GET request: {}", request);
+
+            return handleResponse(httpClient.send(request, HttpResponse.BodyHandlers.ofString()), responseType);
+        } catch (IOException | InterruptedException e) {
+            log.error("Error in API request: " + e.getMessage());
+            throw new ApiRequestException("API request error", e);
+        }
+    }
+
+    private HttpRequest buildRequest(String endpointUrl, Optional<String> apiKey, HttpRequest.BodyPublisher bodyPublisher, String method) {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .uri(URI.create(endpointUrl))
+                .header("Content-Type", "application/json");
+
+        apiKey.ifPresent(s -> requestBuilder.header("x-api-key", s));
+
+        if ("POST".equals(method)) {
+            requestBuilder.POST(bodyPublisher);
+        } else if ("GET".equals(method)) {
+            requestBuilder.GET();
+        }
+
+        return requestBuilder.build();
+    }
+
+    private <T> T handleResponse(HttpResponse<String> response, Class<T> responseType) throws IOException {
+        if (response.statusCode() == 200) {
+            return objectMapper.readValue(response.body(), responseType);
+        } else {
+            log.error("Failed to get response: Status Code = " + response.statusCode());
+            log.debug(response.toString());
+            throw new ApiRequestException("Response status code: " + response.statusCode());
+        }
+    }
+}

--- a/src/main/java/com/aerotrack/utils/clients/apigateway/ApiGatewayClient.java
+++ b/src/main/java/com/aerotrack/utils/clients/apigateway/ApiGatewayClient.java
@@ -1,0 +1,58 @@
+package com.aerotrack.utils.clients.apigateway;
+
+import com.aerotrack.model.exceptions.AerotrackClientException;
+import com.aerotrack.model.exceptions.ApiRequestException;
+import com.aerotrack.model.entities.FlightPair;
+import com.aerotrack.model.protocol.ScanQueryRequest;
+import com.aerotrack.model.protocol.ScanQueryResponse;
+import com.aerotrack.utils.clients.ApiClientWrapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@AllArgsConstructor
+public class ApiGatewayClient {
+    private final static String personalEndpointUrl = "https://f1muce19kh.execute-api.eu-west-1.amazonaws.com/prod/scan";
+    private final static String alphaEndpointUrl = "https://u4ck1qvmfe.execute-api.eu-west-1.amazonaws.com/prod/scan";
+    private final static String prodEndpointUrl = "https://bfq0c9l0dl.execute-api.eu-west-1.amazonaws.com/prod/scan";
+    private final static String apiKey = "z9inDLaWtOamHqvOCl25w33KtSbqVpOf61oPHGhK";
+
+    private final ApiClientWrapper apiClientWrapper;
+
+    public static ApiGatewayClient create() {
+        return new ApiGatewayClient(new ApiClientWrapper());
+    }
+
+    public List<FlightPair> getBestFlight(String startDateString,String endDateString,String minDurationString,String maxDurationString,List<String> departureAirports,Boolean returnToSameAirport, List<String> destinationAirports){
+        ScanQueryRequest scanQueryRequest = buildScanQueryRequest(startDateString,endDateString,minDurationString,maxDurationString,departureAirports,returnToSameAirport,destinationAirports);
+        return sendScanQueryRequest(scanQueryRequest).getFlightPairs();
+    }
+
+    public ScanQueryRequest buildScanQueryRequest(String startDateString,String endDateString,String minDurationString,String maxDurationString,List<String> departureAirports,Boolean returnToSameAirport, List<String> destinationAirports) {
+        ScanQueryRequest.ScanQueryRequestBuilder builder = ScanQueryRequest.builder();
+
+        // Imposta i valori dal flightInfoFields
+        builder.minDays(Integer.valueOf(minDurationString));
+        builder.maxDays(Integer.valueOf(maxDurationString));
+        builder.availabilityStart(startDateString);
+        builder.availabilityEnd(endDateString);
+        builder.departureAirports(departureAirports);
+        builder.returnToSameAirport(returnToSameAirport);
+        builder.destinationAirports(destinationAirports);
+        return builder.build();
+    }
+    public ScanQueryResponse sendScanQueryRequest(ScanQueryRequest scanQueryRequest) {
+        try {
+            return apiClientWrapper.sendPostRequest(personalEndpointUrl, Optional.of(apiKey), scanQueryRequest, ScanQueryResponse.class);
+        } catch (ApiRequestException e) {
+            log.error("Error in API request: " + e.getMessage());
+            throw new AerotrackClientException(e); // Rilancia l'eccezione per consentire la gestione a livelli superiori, se necessario
+        }
+    }
+}
+
+
+

--- a/src/main/java/com/aerotrack/utils/clients/dynamodb/AerotrackDynamoDbClient.java
+++ b/src/main/java/com/aerotrack/utils/clients/dynamodb/AerotrackDynamoDbClient.java
@@ -1,10 +1,7 @@
 package com.aerotrack.utils.clients.dynamodb;
 
-import com.aerotrack.model.Flight;
-import com.aerotrack.model.TableObject;
+import com.aerotrack.model.entities.Flight;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;

--- a/src/main/java/com/aerotrack/utils/clients/ryanair/RyanairClient.java
+++ b/src/main/java/com/aerotrack/utils/clients/ryanair/RyanairClient.java
@@ -1,86 +1,70 @@
 package com.aerotrack.utils.clients.ryanair;
 
-import com.aerotrack.model.Flight;
+import com.aerotrack.model.entities.Flight;
+import com.aerotrack.model.exceptions.ApiRequestException;
+import com.aerotrack.utils.clients.ApiClientWrapper;
 import lombok.AllArgsConstructor;
-import okhttp3.Headers;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+@Slf4j
 @AllArgsConstructor
 public class RyanairClient {
-    OkHttpClient httpClient;
+    private final ApiClientWrapper apiClientWrapper;
+
     public static RyanairClient create() {
-        return new RyanairClient(new OkHttpClient());
+        return new RyanairClient(new ApiClientWrapper());
     }
 
     private static final String RYANAIR_AVAILABILITY_API = "https://www.ryanair.com/api/booking/v4/it-it/availability?ADT=1&Origin=%s" +
             "&Destination=%s&IncludeConnectingFlights=false&Disc=0&DateOut=%s&RoundTrip=false&ToUs=AGREED";
 
-
-    public List<Flight> getFlights(String fromAirportCode, String toAirportCode, LocalDate date) throws IOException {
+    public List<Flight> getFlights(String fromAirportCode, String toAirportCode, LocalDate date) {
         String ryanairURL = String.format(RYANAIR_AVAILABILITY_API, fromAirportCode, toAirportCode, date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 
         List<Flight> flights = new ArrayList<>();
-        JSONObject flightDetails = new JSONObject(getHttpResponse(ryanairURL));
+        try {
+            JSONObject flightDetails = new JSONObject(apiClientWrapper.sendGetRequest(ryanairURL, Optional.empty(), String.class));
 
-        JSONArray trips = flightDetails.optJSONArray("trips");
-        if (trips == null || trips.isEmpty()) {
-            return flights;
-        }
+            JSONArray trips = flightDetails.optJSONArray("trips");
+            if (trips == null || trips.isEmpty()) {
+                return flights;
+            }
 
-        JSONArray dates = trips.getJSONObject(0).optJSONArray("dates");
-        if (dates == null || dates.isEmpty()) {
-            return flights;
-        }
+            JSONArray dates = trips.getJSONObject(0).optJSONArray("dates");
+            if (dates == null || dates.isEmpty()) {
+                return flights;
+            }
 
-        JSONArray flightsArray = dates.getJSONObject(0).optJSONArray("flights");
-        if (flightsArray == null || flightsArray.isEmpty()) {
-            return flights;
-        }
+            JSONArray flightsArray = dates.getJSONObject(0).optJSONArray("flights");
+            if (flightsArray == null || flightsArray.isEmpty()) {
+                return flights;
+            }
 
-        for (int i = 0; i < flightsArray.length(); i++) {
-            JSONObject flight = flightsArray.getJSONObject(i);
+            for (int i = 0; i < flightsArray.length(); i++) {
+                JSONObject flight = flightsArray.getJSONObject(i);
 
-            String timeFrom = flight.getJSONArray("timeUTC").getString(0);
-            String timeTo = flight.getJSONArray("timeUTC").getString(1);
-            double price = flight.getJSONObject("regularFare").getJSONArray("fares").getJSONObject(0).getDouble("amount");
-            String flightNumber = flight.getString("flightNumber");
+                String timeFrom = flight.getJSONArray("timeUTC").getString(0);
+                String timeTo = flight.getJSONArray("timeUTC").getString(1);
+                double price = flight.getJSONObject("regularFare").getJSONArray("fares").getJSONObject(0).getDouble("amount");
+                String flightNumber = flight.getString("flightNumber");
 
-            Flight flightItem = new Flight(fromAirportCode, toAirportCode, timeFrom, timeTo, flightNumber, price);
-            flights.add(flightItem);
+                Flight flightItem = new Flight(fromAirportCode, toAirportCode, timeFrom, timeTo, flightNumber, price);
+                flights.add(flightItem);
+            }
+        } catch (Exception e) {
+            // Handle exception (log or throw as appropriate)
+            log.error(e.getMessage());
+            throw new RuntimeException("Caught exception while calling Ryanair API.", e);
         }
 
         return flights;
-    }
-
-    private static Headers getDefaultHeaders() {
-        return new Headers.Builder()
-                .add("Cookie", "rid.sig=jyna6R42wntYgoTpqvxHMK7H+KyM6xLed+9I3KsvYZaVt7P36AL6zp9dGFPu5uVxaIiFpNXrszr+LfNCdY3IT3oCSYLeNv/ujtjsDqOzkY66AL3V6kH2vsK+au12X21HkZ4S8GaG8CoBmm/m0rLsOKYkxtw+U3+ejBaPc15jJjKXnc3owMBg82SNbqyKjVd6Z6qcsoE25p3RmlcaHuHC3GBf1yIGtlqeQun3Mj0vmSURVPQBjK65pge2zGBymoORV6PsmZ0Nabv73gS2VkhG+Eccz5iSIRPrZm5cloi/941TFo8oiXdyqvTMx/ozox2fkvaKB2vd/goSx543TxPdKoGKRLaDY3FoIepe6I46UFvXEZYszzugXHYRnp0lbIn/HPyvHH/iW/TXRrqsELQabKd1hH+Ut1ZgpfsKEtwDVyL7mVvi1qEOqHddSVKCN/439KxQqi9K03dQDm+knQaLRpzZL8EYqCeSaosMOeEhc2CAYWLW2D5jH5iTot0YiyaN3QJFE59H3MYDpGjoZfTfen83yVSpT8DBahOOr6Eibv62bKQXBxel5kIm75dZB26iUzmkBs1Iags291UJ8wpu/GtBD1rghlZoRJt9u3ASkAj3P85dBcV8MwGykVWJ4mCO; mkt=/gb/en/; .AspNetCore.Session=CfDJ8NJy2CjeBXdEiTlIkEo9jP1x6eP6igWNkoeL9uCto1qdz97HQLRlCAJWIhw97YY5uemEBnTrcLNnoB7lqKOnEJRzF%2F4yhGKN9A5COUteaQmZduO6o2whfYqdyD1Qd%2B%2BH6EXjFP4cd0DtvPDwguugs%2Bc684C2CSfw16lyvYFtSkvU; fr-correlation-id=b8d2a2fe-383b-44fa-8c4a-ba6cab8c994d; rid=034ed121-51ec-4cac-9196-97a50ee42d2c; RY_COOKIE_CONSENT=true; STORAGE_PREFERENCES={\"STRICTLY_NECESSARY\":true,\"PERFORMANCE\":false,\"FUNCTIONAL\":false,\"TARGETING\":false,\"SOCIAL_MEDIA\":false,\"PIXEL\":false,\"GANALYTICS\":true,\"__VERSION\":2}; myRyanairID=")
-                .add("User-Agent", "Mozilla/5.0 (Linux; Android 10; Pixel 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Mobile Safari/537.36")
-                .add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
-                .add("Accept-Language", "en-US,en;q=0.5")
-                .build();
-    }
-
-    private String getHttpResponse(String ryanairURL) throws IOException{
-        Request request = new Request.Builder()
-                .url(ryanairURL)
-                .headers(getDefaultHeaders())
-                .build();
-
-        try (Response response = httpClient.newCall(request).execute()) {
-            if (!response.isSuccessful() || response.body() == null)
-                throw new IOException("Unexpected response: " + response);
-            return response.body().string();
-        }
     }
 }

--- a/src/test/java/com/aerotrack/utils/clients/AerotrackDynamoDbClientTest.java
+++ b/src/test/java/com/aerotrack/utils/clients/AerotrackDynamoDbClientTest.java
@@ -1,0 +1,49 @@
+package com.aerotrack.utils.clients;
+
+import com.aerotrack.model.entities.Flight;
+import com.aerotrack.utils.clients.dynamodb.AerotrackDynamoDbClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class AerotrackDynamoDbClientTest {
+    @Mock
+    private DynamoDbTable<Flight> mockFlightTable;
+    @Mock
+    private PageIterable<Flight> mockPageIterable;
+    @Mock
+    private SdkIterable<Flight> mockSdkIterable;
+    private AerotrackDynamoDbClient aerotrackDynamoDbClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        aerotrackDynamoDbClient = new AerotrackDynamoDbClient(mockFlightTable);
+    }
+
+    @Test
+    void scanFlightsBetweenDates_Success() {
+        Flight flight = new Flight("VCE", "DUB", "2021-01-01", "2021-01-02", "FR830", 50);
+
+        when(mockFlightTable.query(any(QueryConditional.class))).thenReturn(mockPageIterable);
+        when(mockPageIterable.items()).thenReturn(mockSdkIterable);
+        when(mockSdkIterable.stream()).thenReturn(Stream.of(flight));
+
+        List<Flight> result = aerotrackDynamoDbClient.scanFlightsBetweenDates("LAX", "JFK", "2023-01-01", "2023-01-10");
+
+        assertEquals(1, result.size());
+        assertEquals(result.get(0), flight);
+    }
+}

--- a/src/test/java/com/aerotrack/utils/clients/AerotrackS3ClientTest.java
+++ b/src/test/java/com/aerotrack/utils/clients/AerotrackS3ClientTest.java
@@ -1,0 +1,73 @@
+package com.aerotrack.utils.clients;
+
+import com.aerotrack.utils.clients.s3.AerotrackS3Client;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AerotrackS3ClientTest {
+    @Mock
+    private S3Client mockS3Client;
+    @Mock
+    private ResponseInputStream<GetObjectResponse> mockResponseStream;
+    private AerotrackS3Client aerotrackS3Client;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        aerotrackS3Client = new AerotrackS3Client(mockS3Client);
+    }
+
+    @Test
+    void getStringObjectFromS3_Success() throws Exception {
+        String mockS3Response = "Test S3 String Content";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(mockS3Response.getBytes(StandardCharsets.UTF_8));
+        when(mockResponseStream.readAllBytes()).thenReturn(mockS3Response.getBytes(StandardCharsets.UTF_8));
+        when(mockS3Client.getObject(any(GetObjectRequest.class))).thenReturn(mockResponseStream);
+
+        String result = aerotrackS3Client.getStringObjectFromS3("test-key");
+
+        assertEquals("Test S3 String Content", result);
+    }
+
+    @Test
+    void getJsonObjectFromS3_Success() throws Exception {
+        String json = "{\"key\": \"value\"}";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+        when(mockResponseStream.readAllBytes()).thenReturn(json.getBytes(StandardCharsets.UTF_8));
+        when(mockS3Client.getObject(any(GetObjectRequest.class))).thenReturn(mockResponseStream);
+
+        JSONObject result = aerotrackS3Client.getJsonObjectFromS3("test-key");
+
+        assertEquals("value", result.getString("key"));
+    }
+
+    @Test
+    void putJsonObjectToS3_Success() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key", "value");
+        when(mockS3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(PutObjectResponse.builder().build());
+
+        aerotrackS3Client.putJsonObjectToS3(mockS3Client, "bucket-name", "object-key", jsonObject);
+
+        verify(mockS3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+}

--- a/src/test/java/com/aerotrack/utils/clients/ApiGatewayClientTest.java
+++ b/src/test/java/com/aerotrack/utils/clients/ApiGatewayClientTest.java
@@ -1,0 +1,58 @@
+package com.aerotrack.utils.clients;
+
+import com.aerotrack.model.entities.FlightPair;
+import com.aerotrack.model.exceptions.AerotrackClientException;
+import com.aerotrack.model.exceptions.ApiRequestException;
+import com.aerotrack.model.protocol.ScanQueryRequest;
+import com.aerotrack.model.protocol.ScanQueryResponse;
+import com.aerotrack.utils.clients.apigateway.ApiGatewayClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ApiGatewayClientTest {
+
+    @Mock
+    private ApiClientWrapper mockApiClientWrapper;
+
+    private ApiGatewayClient apiGatewayClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        apiGatewayClient = new ApiGatewayClient(mockApiClientWrapper);
+    }
+
+    @Test
+    void getBestFlight_Success() {
+        // Mock the ScanQueryResponse
+        ScanQueryResponse mockResponse = new ScanQueryResponse();
+        mockResponse.setFlightPairs(Arrays.asList(new FlightPair(), new FlightPair())); // Add mock FlightPairs
+
+        when(mockApiClientWrapper.sendPostRequest(anyString(), any(), any(ScanQueryRequest.class), eq(ScanQueryResponse.class)))
+                .thenReturn(mockResponse);
+
+        List<FlightPair> result = apiGatewayClient.getBestFlight("2023-01-01", "2023-01-10", "3", "7", Arrays.asList("LAX"), true, Arrays.asList("JFK"));
+
+        assertNotNull(result);
+        assertEquals(2, result.size()); // Assuming 2 FlightPairs were mocked
+    }
+
+    @Test
+    void getBestFlight_ApiException() {
+        when(mockApiClientWrapper.sendPostRequest(anyString(), any(), any(ScanQueryRequest.class), eq(ScanQueryResponse.class)))
+                .thenThrow(new ApiRequestException("API request failed"));
+
+        assertThrows(AerotrackClientException.class, () ->
+                apiGatewayClient.getBestFlight("2023-01-01", "2023-01-10", "3", "7", List.of("LAX"), true, List.of("JFK"))
+        );
+    }
+}

--- a/src/test/java/com/aerotrack/utils/clients/RyanairClientTest.java
+++ b/src/test/java/com/aerotrack/utils/clients/RyanairClientTest.java
@@ -1,0 +1,57 @@
+package com.aerotrack.utils.clients;
+
+import com.aerotrack.model.entities.Flight;
+import com.aerotrack.utils.clients.ryanair.RyanairClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+class RyanairClientTest {
+    @Mock
+    private ApiClientWrapper mockApiClientWrapper;
+    private RyanairClient ryanairClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        ryanairClient = new RyanairClient(mockApiClientWrapper);
+    }
+
+    @Test
+    void getFlights_Success() {
+        String mockResponse = "{ \"trips\": [{ \"dates\": [{ \"flights\": [" +
+                "{\"timeUTC\": [\"2023-01-01T12:00:00\", \"2023-01-01T15:00:00\"], " +
+                "\"regularFare\": {\"fares\": [{\"amount\": 100.0}]}, " +
+                "\"flightNumber\": \"FR123\"}]}]}]}";
+        when(mockApiClientWrapper.sendGetRequest(anyString(), eq(Optional.empty()), eq(String.class)))
+                .thenReturn(mockResponse);
+
+        List<Flight> result = ryanairClient.getFlights("LAX", "JFK", LocalDate.of(2023, 1, 1));
+
+        assertNotNull(result);
+        assertEquals(1, result.size()); // Assuming 1 mock Flight was returned
+        Flight flight = result.get(0);
+        assertEquals("FR123", flight.getFlightNumber());
+        assertEquals(100.0, flight.getPrice());
+    }
+
+    @Test
+    void getFlights_NoFlightsAvailable() {
+        String mockResponse = "{ \"trips\": [] }"; // Simulate a response with no flights
+        when(mockApiClientWrapper.sendGetRequest(anyString(), eq(Optional.empty()), eq(String.class)))
+                .thenReturn(mockResponse);
+
+        List<Flight> result = ryanairClient.getFlights("LAX", "JFK", LocalDate.of(2023, 1, 1));
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Descrizione

aggiunto un ApiGatewayClient per interagire in modo semplice con Api Gateway, inserito in questa classe per futuri integration tests. Refactorato classi in pacchetti specifici perché a thomas piace così. Aggiunto build and deploy scripts per assicurare CI/CD

## Tests

aggiunto Unit tests per ogni classe

`mvn clean package`

unit test funzionanti su QueryLambda